### PR TITLE
Make 2nd layer links optional in HeaderMenu

### DIFF
--- a/components/HeaderMenu/HeaderMenu.tsx
+++ b/components/HeaderMenu/HeaderMenu.tsx
@@ -45,7 +45,7 @@ const useStyles = createStyles((theme) => ({
 }));
 
 interface HeaderSearchProps {
-  links: { link: string; label: string; links: { link: string; label: string }[] }[];
+  links: { link: string; label: string; links?: { link: string; label: string }[] }[];
 }
 
 export function HeaderMenu({ links }: HeaderSearchProps) {


### PR DESCRIPTION
Currently you get TS error if you don't supply links argument to menu links. 

If you supply empty array you get a dropdown with the link item, and the dropdown is empty.

Same bug might apply to other menu components as well.