### PR TITLE
fix `NavbarSearch`'s style

### DIFF
--- a/components/NavbarSearch/NavbarSearch.tsx
+++ b/components/NavbarSearch/NavbarSearch.tsx
@@ -172,7 +172,7 @@ export function NavbarSearch() {
         icon={<Search size={12} />}
         rightSectionWidth={70}
         rightSection={<Code className={classes.searchCode}>Ctrl + K</Code>}
-        styles={{ rightSection: { pointerEvents: 'none' } }}
+        styles={{ rightSection: { marginRight: 5, pointerEvents: 'none' } }}
         mb="sm"
       />
 


### PR DESCRIPTION
add `margin-right`

<img width="397" alt="image" src="https://user-images.githubusercontent.com/359395/172575310-07c2ef52-4934-4a17-bb4c-26c4c5f5ffb8.png">
