### PR TITLE
Add inline editable text

### DIFF
--- a/components/InlineEditableText/InlineEditableText.story.tsx
+++ b/components/InlineEditableText/InlineEditableText.story.tsx
@@ -4,6 +4,6 @@ import attributes from './attributes.json';
 import { StoryWrapper } from '../../src/components/StoryWrapper/StoryWrapper';
 import { InlineEditableText } from './InlineEditableText';
 
-storiesOf('InlineTextInput', module).add('InputTooltip', () => (
+storiesOf('InlineTextInput', module).add('InlineTextInput', () => (
   <StoryWrapper attributes={attributes} component={InlineEditableText} />
 ));

--- a/components/InlineEditableText/InlineEditableText.story.tsx
+++ b/components/InlineEditableText/InlineEditableText.story.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import attributes from './attributes.json';
+import { StoryWrapper } from '../../src/components/StoryWrapper/StoryWrapper';
+import { InlineEditableText } from './InlineEditableText';
+
+storiesOf('InlineTextInput', module).add('InputTooltip', () => (
+  <StoryWrapper attributes={attributes} component={InlineEditableText} />
+));

--- a/components/InlineEditableText/InlineEditableText.tsx
+++ b/components/InlineEditableText/InlineEditableText.tsx
@@ -5,7 +5,7 @@ import { Check, X } from 'tabler-icons-react';
 
 export function InlineEditableText() {
   const theme = useMantineTheme();
-  const [text, setText] = useState<string>('');
+  const [text, setText] = useState<string>('Inline editable text (click to edit)');
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -23,25 +23,24 @@ export function InlineEditableText() {
   );
 
   const handleCancel = useCallback(() => {
-    form.reset();
-    setText(text);
+    form.setFieldValue('value', text);
     setIsEditing(false);
     inputRef.current && inputRef.current.blur();
-  }, [text, form, setText, setIsEditing, inputRef]);
+  }, [form, text, setIsEditing, inputRef]);
 
   const textInput = (
     <TextInput
       ref={inputRef}
       autoFocus={isEditing}
       variant="filled"
-      value={text}
+      value={form.values.value}
       readOnly={!isEditing}
       placeholder="(click to edit)"
       onClick={() => setIsEditing(true)}
       onChange={(event) => {
         form.setFieldValue('value', event.currentTarget.value);
-        setText(event.currentTarget.value);
       }}
+      sx={{ width: '400px' }}
       styles={{
         filledVariant: {
           backgroundColor: isEditing ? theme.colors.gray[2] : 'white',
@@ -77,7 +76,7 @@ export function InlineEditableText() {
 
   return (
     <>
-      <form onSubmit={form.onSubmit(({ value }) => setText(value))}>
+      <form onSubmit={form.onSubmit(({ value }) => handleSubmit(value))}>
         <Popover
           position="bottom"
           placement="end"
@@ -86,6 +85,8 @@ export function InlineEditableText() {
           onFocus={() => inputRef.current && inputRef.current.focus()}
           onClose={handleCancel}
           target={textInput}
+          closeOnEscape
+          closeOnClickOutside
         >
           <Group position="right" spacing="xs">
             {submitButton}

--- a/components/InlineEditableText/InlineEditableText.tsx
+++ b/components/InlineEditableText/InlineEditableText.tsx
@@ -1,0 +1,98 @@
+import { useCallback, useRef, useState } from 'react';
+import { Button, Group, Popover, TextInput, useMantineTheme } from '@mantine/core';
+import { useForm } from '@mantine/hooks';
+import { Check, X } from 'tabler-icons-react';
+
+export function InlineEditableText() {
+  const theme = useMantineTheme();
+  const [text, setText] = useState<string>('');
+  const [isEditing, setIsEditing] = useState<boolean>(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const form = useForm({
+    initialValues: { value: text },
+  });
+
+  const handleSubmit = useCallback(
+    (value: string) => {
+      setText(value);
+      setIsEditing(false);
+      inputRef.current && inputRef.current.blur();
+    },
+    [setText, setIsEditing, inputRef]
+  );
+
+  const handleCancel = useCallback(() => {
+    form.reset();
+    setText(text);
+    setIsEditing(false);
+    inputRef.current && inputRef.current.blur();
+  }, [text, form, setText, setIsEditing, inputRef]);
+
+  const textInput = (
+    <TextInput
+      ref={inputRef}
+      autoFocus={isEditing}
+      variant="filled"
+      value={text}
+      readOnly={!isEditing}
+      placeholder="(click to edit)"
+      onClick={() => setIsEditing(true)}
+      onChange={(event) => {
+        form.setFieldValue('value', event.currentTarget.value);
+        setText(event.currentTarget.value);
+      }}
+      styles={{
+        filledVariant: {
+          backgroundColor: isEditing ? theme.colors.gray[2] : 'white',
+          '&:hover': {
+            background: theme.colors.gray[2],
+          },
+        },
+      }}
+    />
+  );
+
+  const cancelButton = (
+    <Button variant="subtle" size="xs" onClick={handleCancel}>
+      <X size={16} />
+    </Button>
+  );
+
+  const submitButton = (
+    <Button
+      type="submit"
+      variant="outline"
+      size="xs"
+      onClick={() => {
+        handleSubmit(form.values.value);
+      }}
+      onSubmit={() => {
+        handleSubmit(form.values.value);
+      }}
+    >
+      <Check size={16} />
+    </Button>
+  );
+
+  return (
+    <>
+      <form onSubmit={form.onSubmit(({ value }) => setText(value))}>
+        <Popover
+          position="bottom"
+          placement="end"
+          spacing="xs"
+          opened={isEditing}
+          onFocus={() => inputRef.current && inputRef.current.focus()}
+          onClose={handleCancel}
+          target={textInput}
+        >
+          <Group position="right" spacing="xs">
+            {submitButton}
+            {cancelButton}
+          </Group>
+        </Popover>
+      </form>
+    </>
+  );
+}

--- a/components/InlineEditableText/attributes.json
+++ b/components/InlineEditableText/attributes.json
@@ -1,0 +1,16 @@
+{
+  "title": "Inline editable text",
+  "category": "inputs",
+  "author": "tuliren",
+  "dependencies": [
+    "/core/button/",
+    "/core/group/",
+    "/core/popover/",
+    "/core/text-input/",
+    "tabler-icons-react"
+  ],
+  "canvas": {
+    "center": true,
+    "maxWidth": 420
+  }
+}

--- a/components/InlineEditableText/attributes.json
+++ b/components/InlineEditableText/attributes.json
@@ -7,6 +7,7 @@
     "/core/group/",
     "/core/popover/",
     "/core/text-input/",
+    "/form/use-form/",
     "tabler-icons-react"
   ],
   "canvas": {

--- a/components/index.ts
+++ b/components/index.ts
@@ -39,6 +39,7 @@ export { CurrencyInput } from './CurrencyInput/CurrencyInput';
 export { FloatingLabelInput } from './FloatingLabelInput/FloatingLabelInput';
 export { ForgotPasswordInput } from './ForgotPasswordInput/ForgotPasswordInput';
 export { ImageCheckboxes } from './ImageCheckboxes/ImageCheckboxes';
+export { InlineEditableText } from './InlineEditableText/InlineEditableText';
 export { InputTooltip } from './InputTooltip/InputTooltip';
 export { InputValidation } from './InputValidation/InputValidation';
 export { InputWithButton } from './InputWithButton/InputWithButton';

--- a/src/components/ComponentCanvas/CanvasHeader/get-dependency-info.tsx
+++ b/src/components/ComponentCanvas/CanvasHeader/get-dependency-info.tsx
@@ -5,9 +5,17 @@ import { MantineIcon } from '../icons/MantineIcon';
 import { NpmIcon } from '../icons/NpmIcon';
 
 export function getDependencyInfo(url: string) {
-  if (url.startsWith('/core') || url.startsWith('/hooks') || url.startsWith('/others')) {
+  if (
+    url.startsWith('/core') ||
+    url.startsWith('/hooks') ||
+    url.startsWith('/form') ||
+    url.startsWith('/others')
+  ) {
     const _name = url.split('/')[2];
-    const name = url.startsWith('/hooks') ? _name : _name.split('-').map(upperFirst).join('');
+    const name =
+      url.startsWith('/hooks') || url.startsWith('/form')
+        ? _name
+        : _name.split('-').map(upperFirst).join('');
 
     return {
       name,


### PR DESCRIPTION
## Context
Thank you for this amazing UI library. When I tried to find an inline text editing library for React, I could not find one that works well with Mantine. So I build this one. Hope that it is helpful to others as well.

## Summary
- The text looks normal, but is editable inline.
  <img width="430" alt="Screen Shot 2022-07-16 at 13 59 42" src="https://user-images.githubusercontent.com/1933157/179371796-326de421-b264-4061-a77d-396ab1911fe4.png">

- When the text is hovered on, its background will become gray and the cursor will become text, to indicate that it is editable.
  <img width="430" alt="Screen Shot 2022-07-16 at 13 59 38" src="https://user-images.githubusercontent.com/1933157/179371801-f10c870f-ebd3-4339-8eb4-9744662cca12.png">

- Click on the text will enter the editing mode. There will be a popover showing a submit and a cancel button.
  <img width="424" alt="Screen Shot 2022-07-16 at 13 59 47" src="https://user-images.githubusercontent.com/1933157/179371815-25b21146-2b2b-4e08-8e90-ea86b059645b.png">

## Discussion
- Many of the inline editing libraries use different elements for showing and editing the text. However, using that pattern, when switching between the view and editing mode, I found it very hard to keep the text at the exact same place without introducing any pixel shift. That's why in this example, I used `TextInput` to present the text directly to avoid such trouble.
- An extra feature is to add hotkey (`Esc`) to quit the editing mode. I think that this is not essential to this example. But I can implement that as well if needed.
