### PR TITLE
Fix HeaderActionProps interface error in HeaderAction.tsx

### DIFF
--- a/components/HeaderAction/HeaderAction.tsx
+++ b/components/HeaderAction/HeaderAction.tsx
@@ -55,7 +55,7 @@ const useStyles = createStyles((theme) => ({
 }));
 
 interface HeaderActionProps {
-  links: { link: string; label: string; links: { link: string; label: string }[] }[];
+  links: { link: string; label: string; links?: { link: string; label: string }[] }[];
 }
 
 export function HeaderAction({ links }: HeaderActionProps) {


### PR DESCRIPTION
Fix typescript complaints about the interface HeaderActionProps structure. It's required to add links as optional.