### PR TITLE
Adjust z-index value of header/Nav bar

### DIFF
--- a/src/components/Layout/Header/Header.styles.ts
+++ b/src/components/Layout/Header/Header.styles.ts
@@ -5,7 +5,7 @@ export const HEADER_HEIGHT = 60;
 export default createStyles((theme) => ({
   header: {
     position: 'fixed',
-    zIndex: 10,
+    zIndex: 99,
     top: 0,
     left: 0,
     right: 0,


### PR DESCRIPTION
* Fix the Header being overflowed by the examples were they have higher z-index values when scrolling. 
* - currently easily reproducible by going to https://ui.mantine.dev/category/inputs, and trying to scroll the page.