### PR TITLE
Fix password test to fit errortest

### DIFF
--- a/components/AuthenticationForm/AuthenticationForm.tsx
+++ b/components/AuthenticationForm/AuthenticationForm.tsx
@@ -27,7 +27,7 @@ export function AuthenticationForm(props: PaperProps) {
 
     validate: {
       email: (val) => (/^\S+@\S+$/.test(val) ? null : 'Invalid email'),
-      password: (val) => (val.length <= 6 ? 'Password should include at least 6 characters' : null),
+      password: (val) => (val.length <= 5 ? 'Password should include at least 6 characters' : null),
     },
   });
 


### PR DESCRIPTION
This PR adjust the password validation of https://ui.mantine.dev/component/authentication-form to fit the error text.