### PR TITLE
Invalid syntax removed from TableReviews.tsx

### DIFF
--- a/components/TableReviews/TableReviews.tsx
+++ b/components/TableReviews/TableReviews.tsx
@@ -28,13 +28,13 @@ export function TableReviews({ data }: TableReviewsProps) {
     return (
       <tr key={row.title}>
         <td>
-          <Anchor<'a'> size="sm" onClick={(event) => event.preventDefault()}>
+          <Anchor size="sm" onClick={(event) => event.preventDefault()}>
             {row.title}
           </Anchor>
         </td>
         <td>{row.year}</td>
         <td>
-          <Anchor<'a'> size="sm" onClick={(event) => event.preventDefault()}>
+          <Anchor size="sm" onClick={(event) => event.preventDefault()}>
             {row.author}
           </Anchor>
         </td>


### PR DESCRIPTION
The syntax ```<Anchor<'a'> size="sm" onClick={(event) => event.preventDefault()}>{row.title}</Anchor>```  should be invalid and is not a good practice.

![code example](https://user-images.githubusercontent.com/46455250/206843924-fe7649c8-e88d-4ef8-91f9-bc12b1126904.png)
