### PR TITLE
Fix: Added missing LeadGrid example dependency

### DIFF
--- a/components/LeadGrid/attributes.json
+++ b/components/LeadGrid/attributes.json
@@ -3,7 +3,11 @@
   "category": "grids",
   "author": "rtivital",
   "responsive": true,
-  "dependencies": ["/core/simple-grid/", "/core/grid/", "/core/"],
+  "dependencies": [
+    "/core/simple-grid/",
+    "/core/grid/",
+    "/core/container/"
+  ],
   "canvas": {
     "center": false
   }


### PR DESCRIPTION
There is a missing "Container" dependency in an example of [Grid with leading item](https://ui.mantine.dev/category/grids). The bad link directs to a 404 page that told me to make this pull request :)

Adding a proper container link in attributes.json should fix the issue.