### PR TITLE
fix form input props reference

### DIFF
--- a/components/GetInTouchSimple/GetInTouchSimple.tsx
+++ b/components/GetInTouchSimple/GetInTouchSimple.tsx
@@ -62,7 +62,7 @@ export function GetInTouchSimple() {
         autosize
         name="message"
         variant="filled"
-        {...form.getInputProps('subject')}
+        {...form.getInputProps('message')}
       />
 
       <Group position="center" mt="xl">


### PR DESCRIPTION
This was propably a copy & paste error. Message form should reference message props