### PR TITLE
Fix: Textarea state is bound to subject state

### DIFF
--- a/components/GetInTouchSimple/GetInTouchSimple.tsx
+++ b/components/GetInTouchSimple/GetInTouchSimple.tsx
@@ -62,7 +62,7 @@ export function GetInTouchSimple() {
         autosize
         name="message"
         variant="filled"
-        {...form.getInputProps('subject')}
+        {...form.getInputProps('message')}
       />
 
       <Group position="center" mt="xl">


### PR DESCRIPTION
File: `GetInTouchSimple.tsx` 

The "Message" field state is currently bound to the "Subject" field state