### PR TITLE
fix HeaderMenuColored ts prop type

### DIFF
--- a/components/HeaderMenuColored/HeaderMenuColored.tsx
+++ b/components/HeaderMenuColored/HeaderMenuColored.tsx
@@ -52,7 +52,7 @@ const useStyles = createStyles((theme) => ({
 }));
 
 interface HeaderSearchProps {
-  links: { link: string; label: string; links: { link: string; label: string }[] }[];
+  links: { link: string; label: string; links?: { link: string; label: string }[] }[];
 }
 
 export function HeaderMenuColored({ links }: HeaderSearchProps) {


### PR DESCRIPTION
The nested `links` prop is optional since the component allows links with and without nesting.

the code also checks for undefined when the prop is used  https://github.com/mantinedev/ui.mantine.dev/blob/4202b446b7bfbdabc49106e496d4d0c4b31e0c08/components/HeaderMenuColored/HeaderMenuColored.tsx#L63