### PR TITLE
Fix: NumberInput wrapper not in display flex

### DIFF
--- a/components/QuantityInput/QuantityInput.tsx
+++ b/components/QuantityInput/QuantityInput.tsx
@@ -32,6 +32,10 @@ const useStyles = createStyles((theme) => ({
     },
   },
 
+  inputWrapper: {
+    display: 'flex',
+  },
+
   input: {
     textAlign: 'center',
     paddingRight: `${theme.spacing.sm} !important`,
@@ -71,7 +75,7 @@ export function QuantityInput({ min = 1, max = 10 }: QuantityInputProps) {
         handlersRef={handlers}
         value={value}
         onChange={setValue}
-        classNames={{ input: classes.input }}
+        classNames={{ input: classes.input, wrapper: classes.inputWrapper }}
       />
 
       <ActionIcon<'button'>


### PR DESCRIPTION
I noticed the flex wasn't getting set properly for the NumberInput styles.

Before:
![image](https://user-images.githubusercontent.com/8884882/222182751-59056d2e-630a-4e90-a928-53a2fc299606.png)

After:
![image](https://user-images.githubusercontent.com/8884882/222183279-310fb686-c377-410d-a611-164ec3a81b24.png)

