### PR TITLE
Make links menu optional

### DIFF
--- a/components/HeaderAction/HeaderAction.tsx
+++ b/components/HeaderAction/HeaderAction.tsx
@@ -56,7 +56,7 @@ const useStyles = createStyles((theme) => ({
 }));
 
 interface HeaderActionProps {
-  links: { link: string; label: string; links: { link: string; label: string }[] }[];
+  links: { link: string; label: string; links?: { link: string; label: string }[] }[];
 }
 
 export function HeaderAction({ links }: HeaderActionProps) {


### PR DESCRIPTION
No problem when you declare your HeaderActionProps in json but got an error in editor when you declare in js. By setting it optional we can create a js file with a const links declaration like this:

import { HeaderActionProps } from './HeaderAction';

export const links: HeaderActionProps['links'] = [