### PR TITLE
Fix image source in Hero with bullets

### DIFF
--- a/components/HeroBullets/HeroBullets.tsx
+++ b/components/HeroBullets/HeroBullets.tsx
@@ -113,7 +113,7 @@ export function HeroBullets() {
               </Button>
             </Group>
           </div>
-          <Image src={image.src} className={classes.image} />
+          <Image src={image} className={classes.image} />
         </div>
       </Container>
     </div>


### PR DESCRIPTION
The correct image source in the `img` tag should be `image` instead of `image.src` because the image was imported using `import image from './image.svg';`.

Without this change, the image does not appear when tested locally.