### PR TITLE
Make nested links optional for header docs

### DIFF
--- a/components/HeaderMenuColored/HeaderMenuColored.tsx
+++ b/components/HeaderMenuColored/HeaderMenuColored.tsx
@@ -52,7 +52,7 @@ const useStyles = createStyles((theme) => ({
 }));
 
 interface HeaderSearchProps {
-  links: { link: string; label: string; links: { link: string; label: string }[] }[];
+  links: { link: string; label: string; links?: { link: string; label: string }[] }[];
 }
 
 export function HeaderMenuColored({ links }: HeaderSearchProps) {


### PR DESCRIPTION
As is, the mock data will proc an error with typescript since some of them don't have nested links available. 

Could either update mock data to include empty nested links or update interface to have nested links as an optional field.