### PR TITLE
Fixed interface for links

### DIFF
--- a/components/HeaderAction/HeaderAction.tsx
+++ b/components/HeaderAction/HeaderAction.tsx
@@ -56,7 +56,7 @@ const useStyles = createStyles((theme) => ({
 }));
 
 interface HeaderActionProps {
-  links: { link: string; label: string; links: { link: string; label: string }[] }[];
+  links: { link: string; label: string; links?: { link: string; label: string }[] }[];
 }
 
 export function HeaderAction({ links }: HeaderActionProps) {

--- a/components/HeaderMenu/HeaderMenu.tsx
+++ b/components/HeaderMenu/HeaderMenu.tsx
@@ -44,7 +44,7 @@ const useStyles = createStyles((theme) => ({
 }));
 
 interface HeaderSearchProps {
-  links: { link: string; label: string; links: { link: string; label: string }[] }[];
+  links: { link: string; label: string; links?: { link: string; label: string }[] }[];
 }
 
 export function HeaderMenu({ links }: HeaderSearchProps) {

--- a/components/HeaderMenuColored/HeaderMenuColored.tsx
+++ b/components/HeaderMenuColored/HeaderMenuColored.tsx
@@ -52,7 +52,7 @@ const useStyles = createStyles((theme) => ({
 }));
 
 interface HeaderSearchProps {
-  links: { link: string; label: string; links: { link: string; label: string }[] }[];
+  links: { link: string; label: string; links?: { link: string; label: string }[] }[];
 }
 
 export function HeaderMenuColored({ links }: HeaderSearchProps) {


### PR DESCRIPTION
Hi there!

I found that mock data for links shows error if they do not have links as `undefined`. These components have cases when links are undefined, so it is better to add `undefined` types.