### PR TITLE
fix: typo at GoogleButton.tsx

### DIFF
--- a/lib/AuthenticationForm/GoogleButton.tsx
+++ b/lib/AuthenticationForm/GoogleButton.tsx
@@ -30,5 +30,5 @@ function GoogleIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
 }
 
 export function GoogleButton(props: ButtonProps & React.ComponentPropsWithoutRef<'button'>) {
-  return <Button leftSection={<GoogleIcon />} variant="default" {...props} />;
+  return <Button leftIcon={<GoogleIcon />} variant="default" {...props} />;
 }


### PR DESCRIPTION
there was a small typo at GoogleButton.tsx, instead of leftIcon it was leftSection