### PR TITLE
Update HeaderTabs.module.css

### DIFF
--- a/lib/HeaderTabs/HeaderTabs.module.css
+++ b/lib/HeaderTabs/HeaderTabs.module.css
@@ -19,7 +19,7 @@
     background-color: light-dark(var(--mantine-color-white), var(--mantine-color-dark-8));
   }
 
-  @media (max-width: $mantine-breakpoint-xs) {
+  @media (max-width: mantine-breakpoint-xs) {
     display: none;
   }
 }


### PR DESCRIPTION
Giving CSS term expected error

Fixed: 

Since we are using a CSS file (as indicated by the .css file extension), we should be using CSS variables. However, the $mantine-breakpoint-xs variable is defined using SCSS syntax.