### PR TITLE
Fix: currency sign is not prefixing the amount (resolves #93)

### DIFF
--- a/lib/CarouselCard/CarouselCard.tsx
+++ b/lib/CarouselCard/CarouselCard.tsx
@@ -55,7 +55,7 @@ export function CarouselCard() {
       <Group justify="space-between" mt="md">
         <div>
           <Text fz="xl" span fw={500} className={classes.price}>
-            397$
+              $397
           </Text>
           <Text span fz="sm" c="dimmed">
             {' '}


### PR DESCRIPTION
Fixes tiny typo on `CarouselCard.tsx` the currency sign is not prefixing the amount #93 