### PR TITLE
Remove redundant classes from HeaderSearch example

### DIFF
--- a/lib/HeaderSearch/HeaderSearch.tsx
+++ b/lib/HeaderSearch/HeaderSearch.tsx
@@ -34,11 +34,10 @@ export function HeaderSearch() {
         </Group>
 
         <Group>
-          <Group ml={50} gap={5} className={classes.links} visibleFrom="sm">
+          <Group ml={50} gap={5} visibleFrom="sm">
             {items}
           </Group>
           <Autocomplete
-            className={classes.search}
             placeholder="Search"
             leftSection={<IconSearch style={{ width: rem(16), height: rem(16) }} stroke={1.5} />}
             data={['React', 'Angular', 'Vue', 'Next.js', 'Riot.js', 'Svelte', 'Blitz.js']}


### PR DESCRIPTION
First of all, thank you for all the amazing work!

I was following the `HeaderSearch` example and I noticed that `.links` and `.search` do not exist in `HeaderSearch.module.css`, so I removed redundant references to them from `HeaderSearch.tsx`.

Thank you again!