### PR TITLE
[ui] fix language picker selected image size

### DIFF
--- a/lib/LanguagePicker/LanguagePicker.tsx
+++ b/lib/LanguagePicker/LanguagePicker.tsx
@@ -36,7 +36,7 @@ export function LanguagePicker() {
       <Menu.Target>
         <UnstyledButton className={classes.control} data-expanded={opened || undefined}>
           <Group gap="xs">
-            <Image src={selected.image} width={22} height={22} />
+            <Image src={selected.image} w={22} h={22} />
             <span className={classes.label}>{selected.label}</span>
           </Group>
           <IconChevronDown size={16} className={classes.icon} stroke={1.5} />


### PR DESCRIPTION
Fixes https://github.com/mantinedev/mantine/issues/7781

Using `width` and `height` instead of the shorthand `w` and `h` cause the image to not respect the size given.